### PR TITLE
Using sed command to modify ImageMagick setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ echo 'please check folder converted_jpg'
 </code></pre>
 
 - 需ImageMagick修改參數
-<pre><code>vim /etc/ImageMagick-6/policy.xml</code></pre>
-<pre><code>policy domain="coder" rights="read|write" pattern="PDF"</code></pre>
+<pre><code>sudo sed -i 's/policy domain="coder" rights="none" pattern="PDF"/policy domain="coder" rights="read|write" pattern="PDF"/g' /etc/ImageMagick-6/policy.xml</code></pre>
 
 
 #### 圖像呈現 ####


### PR DESCRIPTION
# Changed log

- It can be useful to run the `sed` command to modify the ImageMagick easily.

These following outputs are about verifying the above command:

```sh
$ cat /etc/ImageMagick-6/policy.xml | grep -i 'pdf'
  <!-- <policy domain="module" rights="none" pattern="{PS,PDF,XPS}" /> -->
  <policy domain="coder" rights="none" pattern="PDF" />
$ sudo sed -i 's/policy domain="coder" rights="none" pattern="PDF"/policy domain="coder" rights="read|write" pattern="PDF"/g' /etc/ImageMagick-6/policy.xml
$ cat /etc/ImageMagick-6/policy.xml | grep -i 'pdf'
  <!-- <policy domain="module" rights="none" pattern="{PS,PDF,XPS}" /> -->
  <policy domain="coder" rights="read|write" pattern="PDF" />
```